### PR TITLE
Add header to query builder

### DIFF
--- a/supabase/lib/query_builder.py
+++ b/supabase/lib/query_builder.py
@@ -29,9 +29,6 @@ def _execute_monkey_patch(self) -> Dict[str, Any]:
     url: str = str(self.session.base_url).rstrip("/")
     query: str = str(self.session.params)
     response = func(f"{url}?{query}", headers=self.session.headers, **additional_kwargs)
-    import pdb
-
-    pdb.set_trace()
     return {
         "data": response.json(),
         "status_code": response.status_code,

--- a/supabase/lib/query_builder.py
+++ b/supabase/lib/query_builder.py
@@ -29,6 +29,9 @@ def _execute_monkey_patch(self) -> Dict[str, Any]:
     url: str = str(self.session.base_url).rstrip("/")
     query: str = str(self.session.params)
     response = func(f"{url}?{query}", headers=self.session.headers, **additional_kwargs)
+    import pdb
+
+    pdb.set_trace()
     return {
         "data": response.json(),
         "status_code": response.status_code,
@@ -68,6 +71,7 @@ class SupabaseQueryBuilder(PostgrestClient):
             "Content-Type": "application/json",
             "Accept-Profile": schema,
             "Content-Profile": schema,
+            "Prefer": "return=representation",
             **headers,
         }
         self.session = AsyncClient(base_url=url, headers=headers)


### PR DESCRIPTION
Context: 

The current monkey-patched query builder does not return rows from the query instead returning an empty string. This is because [postgREST only returns the response when the header `Prefer: return=representation` is included](https://postgrest.org/en/v7.0.0/api.html#deletions). We have introduced this header as a default

Fix #22 