### PR TITLE
tests: ignore 404 when double-checking bucket deletion

### DIFF
--- a/supabase/__init__.py
+++ b/supabase/__init__.py
@@ -4,4 +4,5 @@ from supabase import client, lib
 from supabase.client import Client, create_client
 from supabase.lib.auth_client import SupabaseAuthClient
 from supabase.lib.realtime_client import SupabaseRealtimeClient
-from supabase.lib.storage_client import StorageFileAPI, SupabaseStorageClient
+from supabase.lib.storage import StorageException, StorageFileAPI
+from supabase.lib.storage_client import SupabaseStorageClient

--- a/supabase/lib/__init__.py
+++ b/supabase/lib/__init__.py
@@ -1,3 +1,3 @@
-from supabase.lib import auth_client, realtime_client, storage_client
+from supabase.lib import auth_client, realtime_client, storage, storage_client
 
-__all__ = ["auth_client", "realtime_client", "storage_client"]
+__all__ = ["auth_client", "realtime_client", "storage_client", "storage"]

--- a/supabase/lib/storage/__init__.py
+++ b/supabase/lib/storage/__init__.py
@@ -1,0 +1,2 @@
+from .storage_bucket_api import StorageBucketAPI, StorageException
+from .storage_file_api import StorageFileAPI

--- a/supabase/lib/storage/storage_bucket_api.py
+++ b/supabase/lib/storage/storage_bucket_api.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 from httpx import AsyncClient, Client, HTTPError
 
-__all__ = ["Bucket", "StorageBucketAPI"]
+__all__ = ["Bucket", "StorageBucketAPI", "StorageException"]
 
 _RequestMethod = str
 

--- a/test.ps1
+++ b/test.ps1
@@ -1,6 +1,4 @@
 powershell -Command {
-    $env:SUPABASE_TEST_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTYzNTAwODQ4NywiZXhwIjoxOTUwNTg0NDg3fQ.l8IgkO7TQokGSc9OJoobXIVXsOXkilXl4Ak6SCX5qI8";
-    $env:SUPABASE_TEST_URL = "https://ibrydvrsxoapzgtnhpso.supabase.co";
     poetry install;
     poetry run pytest --cov=./ --cov-report=xml --cov-report=html -vv;
     poetry run pre-commit run --all-files;

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -52,7 +52,7 @@ def delete_left_buckets(
                 except StorageException as e:
                     # Ignore 404 responses since they mean the bucket was already deleted
                     response = e.args[0]
-                    if response["status_code"] != 404:
+                    if response["statusCode"] != 404:
                         raise e
                     continue
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -14,15 +14,15 @@ if TYPE_CHECKING:
     from supabase import Client, StorageFileAPI, SupabaseStorageClient
 
 
-UUID_PREFIX = "pytest-"
+# Global variable to track the ids from the buckets created in the tests run
+temp_test_buckets_ids = []
 
 
 @pytest.fixture(scope="module")
 def uuid_factory() -> Callable[[], str]:
     def method() -> str:
-        """Generate a UUID"""
-        uuid = uuid4().hex[:8]  # Get the first 8 digits part to make it shorter
-        return f"{UUID_PREFIX}{uuid}"
+        """Generate a 8 digits long UUID"""
+        return uuid4().hex[:8]
 
     return method
 
@@ -37,24 +37,19 @@ def storage_client(supabase: Client) -> SupabaseStorageClient:
 def delete_left_buckets(
     request: pytest.FixtureRequest, storage_client: SupabaseStorageClient
 ):
-    """Ensures no test buckets are left"""
+    """Ensures no test buckets are left when a test that created a bucket fails"""
 
     def finalizer():
-        buckets_list = storage_client.list_buckets()
-        if not buckets_list:
-            return
-
-        for bucket in buckets_list:
-            if bucket.id.startswith(UUID_PREFIX):
-                try:
-                    storage_client.empty_bucket(bucket.id)
-                    storage_client.delete_bucket(bucket.id)
-                except StorageException as e:
-                    # Ignore 404 responses since they mean the bucket was already deleted
-                    response = e.args[0]
-                    if response["statusCode"] != 404:
-                        raise e
-                    continue
+        for bucket in temp_test_buckets_ids:
+            try:
+                storage_client.empty_bucket(bucket.id)
+                storage_client.delete_bucket(bucket.id)
+            except StorageException as e:
+                # Ignore 404 responses since they mean the bucket was already deleted
+                response = e.args[0]
+                if response["statusCode"] != 404:
+                    raise e
+                continue
 
     request.addfinalizer(finalizer)
 
@@ -65,12 +60,19 @@ def bucket(
 ) -> str:
     """Creates a test bucket which will be used in the whole storage tests run and deleted at the end"""
     bucket_id = uuid_factory()
+
+    # Store bucket_id in global list
+    global temp_test_buckets_ids
+    temp_test_buckets_ids.append(bucket_id)
+
     storage_client.create_bucket(id=bucket_id)
 
     yield bucket_id
 
     storage_client.empty_bucket(bucket_id)
     storage_client.delete_bucket(bucket_id)
+
+    temp_test_buckets_ids.remove(bucket_id)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
In the last PR we introduced some changes to the tests. One of them was a cleanup function that double-checked all test buckets were deleted after the tests run, since the empty and delete methods of the bucket fixture don't run if the test that created the bucket fails.
Nevertheless, tests were still failing because of two reasons:
1. The cleanup function called list_buckets before the buckets were deleted, so sometimes we face a 404 response, which we have to avoid since that means the bucket has already been deleted.
2. Since we were deleting buckets based on the prefix of their id, when multiple test runs are happening at the same time and one finishes before another one, it would delete all test buckets and tests would fail in the runs that were still going .

The solution to 1) is an easy try and except clause continuing the loop if the status code of the response in the StorageException is a 404.
The solution to 2) is using a list as a global variable to only track the buckets that have been created by the corresponding tests run, in order to delete these in the double_check.