### PR TITLE
fix: pass schema to postgrest initialization 

### DIFF
--- a/supabase/client.py
+++ b/supabase/client.py
@@ -58,7 +58,7 @@ class Client:
             rest_url=self.rest_url,
             supabase_key=self.supabase_key,
             headers=options.headers,
-            schema=options.schema
+            schema=options.schema,
         )
 
     def storage(self) -> SupabaseStorageClient:
@@ -152,10 +152,7 @@ class Client:
 
     @staticmethod
     def _init_postgrest_client(
-        rest_url: str,
-        supabase_key: str,
-        headers: Dict[str, str],
-        schema: str
+        rest_url: str, supabase_key: str, headers: Dict[str, str], schema: str
     ) -> SyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
         client = SyncPostgrestClient(rest_url, headers=headers, schema=schema)

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -58,6 +58,7 @@ class Client:
             rest_url=self.rest_url,
             supabase_key=self.supabase_key,
             headers=options.headers,
+            schema=options.schema
         )
 
     def storage(self) -> SupabaseStorageClient:
@@ -154,9 +155,10 @@ class Client:
         rest_url: str,
         supabase_key: str,
         headers: Dict[str, str],
+        schema: str
     ) -> SyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
-        client = SyncPostgrestClient(rest_url, headers=headers)
+        client = SyncPostgrestClient(rest_url, headers=headers, schema=schema)
         client.auth(token=supabase_key)
         return client
 


### PR DESCRIPTION
Fixes #217

The code was modified to pass options.schema to the _init_postgrest_client function through a new schema parameter to in turn pass the schema information to the SyncPostgrestClient constructor.