### PR TITLE
feat: setting timeout for postgrest-py client

### DIFF
--- a/supabase/client.py
+++ b/supabase/client.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, Union
 
 from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequestBuilder
-from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from httpx import Timeout
+from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 
 from .lib.auth_client import SupabaseAuthClient
 from .lib.client_options import ClientOptions

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -2,11 +2,11 @@ from typing import Any, Dict, Union
 
 from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequestBuilder
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
+from httpx import Timeout
 
 from .lib.auth_client import SupabaseAuthClient
 from .lib.client_options import ClientOptions
 from .lib.storage_client import SupabaseStorageClient
-from httpx import Timeout
 
 class Client:
     """Supabase client class."""

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -48,7 +48,6 @@ class Client:
             auth_url=self.auth_url,
             supabase_key=self.supabase_key,
             client_options=options,
-
         )
         # TODO(fedden): Bring up to parity with JS client.
         # self.realtime: SupabaseRealtimeClient = self._init_realtime_client(
@@ -61,7 +60,6 @@ class Client:
             supabase_key=self.supabase_key,
             headers=options.headers,
             schema=options.schema,
-            timeout=options.timeout
         )
 
     def storage(self) -> SupabaseStorageClient:

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Union
 
-from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequestBuilder
 from httpx import Timeout
+from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequestBuilder
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 
 from .lib.auth_client import SupabaseAuthClient

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -48,6 +48,7 @@ class Client:
             auth_url=self.auth_url,
             supabase_key=self.supabase_key,
             client_options=options,
+
         )
         # TODO(fedden): Bring up to parity with JS client.
         # self.realtime: SupabaseRealtimeClient = self._init_realtime_client(
@@ -60,6 +61,7 @@ class Client:
             supabase_key=self.supabase_key,
             headers=options.headers,
             schema=options.schema,
+            timeout=options.timeout
         )
 
     def storage(self) -> SupabaseStorageClient:

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -1,11 +1,12 @@
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequestBuilder
+from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 
 from .lib.auth_client import SupabaseAuthClient
 from .lib.client_options import ClientOptions
 from .lib.storage_client import SupabaseStorageClient
-
+from httpx import Timeout
 
 class Client:
     """Supabase client class."""
@@ -152,10 +153,14 @@ class Client:
 
     @staticmethod
     def _init_postgrest_client(
-        rest_url: str, supabase_key: str, headers: Dict[str, str], schema: str
+        rest_url: str, 
+        supabase_key: str, 
+        headers: Dict[str, str], 
+        schema: str,
+        timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT
     ) -> SyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
-        client = SyncPostgrestClient(rest_url, headers=headers, schema=schema)
+        client = SyncPostgrestClient(rest_url, headers=headers, schema=schema, timeout=timeout)
         client.auth(token=supabase_key)
         return client
 

--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 from gotrue import SyncMemoryStorage, SyncSupportedStorage
+from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
+from httpx import Timeout
 
 from supabase import __version__
 
@@ -34,6 +36,9 @@ class ClientOptions:
     fetch: Optional[Callable] = None
     """A custom `fetch` implementation."""
 
+    timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT
+    """Timeout passed to the SyncPostgrestClient instance."""
+
     def replace(
         self,
         schema: Optional[str] = None,
@@ -43,6 +48,7 @@ class ClientOptions:
         local_storage: Optional[SyncSupportedStorage] = None,
         realtime: Optional[Dict[str, Any]] = None,
         fetch: Optional[Callable] = None,
+        timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT
     ) -> "ClientOptions":
         """Create a new SupabaseClientOptions with changes"""
         client_options = ClientOptions()
@@ -55,4 +61,5 @@ class ClientOptions:
         client_options.local_storage = local_storage or self.local_storage
         client_options.realtime = realtime or self.realtime
         client_options.fetch = fetch or self.fetch
+        client_options.timeout = timeout or self.timeout
         return client_options

--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional, Union
 
 from gotrue import SyncMemoryStorage, SyncSupportedStorage
-from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from httpx import Timeout
+from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 
 from supabase import __version__
 

--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -1,9 +1,7 @@
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional
 
 from gotrue import SyncMemoryStorage, SyncSupportedStorage
-from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
-from httpx import Timeout
 
 from supabase import __version__
 
@@ -36,9 +34,6 @@ class ClientOptions:
     fetch: Optional[Callable] = None
     """A custom `fetch` implementation."""
 
-    timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT
-    """Timeout passed to the SyncPostgrestClient instance."""
-
     def replace(
         self,
         schema: Optional[str] = None,
@@ -48,7 +43,6 @@ class ClientOptions:
         local_storage: Optional[SyncSupportedStorage] = None,
         realtime: Optional[Dict[str, Any]] = None,
         fetch: Optional[Callable] = None,
-        timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT
     ) -> "ClientOptions":
         """Create a new SupabaseClientOptions with changes"""
         client_options = ClientOptions()
@@ -61,5 +55,4 @@ class ClientOptions:
         client_options.local_storage = local_storage or self.local_storage
         client_options.realtime = realtime or self.realtime
         client_options.fetch = fetch or self.fetch
-        client_options.timeout = timeout or self.timeout
         return client_options

--- a/tests/test_client_options.py
+++ b/tests/test_client_options.py
@@ -13,6 +13,7 @@ def test__client_options__replace__returns_updated_options():
         persist_session=False,
         local_storage=local_storage,
         realtime={"key": "value"},
+        timeout=5
     )
 
     actual = options.replace(schema="new schema")
@@ -23,6 +24,7 @@ def test__client_options__replace__returns_updated_options():
         persist_session=False,
         local_storage=local_storage,
         realtime={"key": "value"},
+        timeout=5
     )
 
     assert actual == expected


### PR DESCRIPTION
postgrest-py accepts a timeout parameter from [v0.8.0](https://github.com/supabase-community/postgrest-py/commit/1ea965a6cb32dacb5f41cd1198f8a970a24731b6)

Added the`timeout` option for the postgrest client and made it optional, with a defaulf of 5sec.

@anand2312 @J0 @dreinon @leynier 
Closes #225 