### PR TITLE
Async Client support & more

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We can then read the keys in the python source code.
 import os
 from supabase import SupabaseClient
 
-url: str = os.environ.get("SUPABASE_URL") 
+url: str = os.environ.get("SUPABASE_URL")
 key: str = os.environ.get("SUPABASE_KEY")
 
 supabase: SupabaseClient = SupabaseClient(url, key)
@@ -98,7 +98,7 @@ This is a sample of how you'd use supabase-py. Functions and tests are WIP
 
 ```python
 import os
-from supabase import SupabaseClient 
+from supabase import SupabaseClient
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
@@ -115,7 +115,7 @@ user = supabase.auth.sign_up(email=random_email, password=random_password)
 
 ```python
 import os
-from supabase import SupabaseClient 
+from supabase import SupabaseClient
 
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
@@ -134,7 +134,7 @@ user = supabase.auth.sign_in(email=random_email, password=random_password)
 
 ```python
 import os
-from supabase import SupabaseClient 
+from supabase import SupabaseClient
 
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
@@ -148,11 +148,11 @@ data = supabase.table("countries").insert({"name":"Germany"}).execute()
 ```python
 async def main():
     import os
-    from supabase import AsyncSupabaseClient 
+    from supabase import AsyncSupabaseClient
 
     url: str = os.environ.get("SUPABASE_TEST_URL")
     key: str = os.environ.get("SUPABASE_TEST_KEY")
-    
+
     async with AsyncSupabaseClient(url, key) as supabase:
         await supabase.table("countries").insert({"name":"Germany"}).execute()
 
@@ -165,7 +165,7 @@ if __name__ == "__main__":
 
 ```python
 import os
-from supabase import SupabaseClient 
+from supabase import SupabaseClient
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
@@ -175,15 +175,15 @@ supabase: SupabaseClient = SupabaseClient(url, key)
 data = supabase.table("countries").select("*").execute()
 ```
 #### (NEW) Async Support
-    
+
 ```python
 async def main():
     import os
-    from supabase import AsyncSupabaseClient 
+    from supabase import AsyncSupabaseClient
 
     url: str = os.environ.get("SUPABASE_TEST_URL")
     key: str = os.environ.get("SUPABASE_TEST_KEY")
-    
+
     async with AsyncSupabaseClient(url, key) as supabase:
         await supabase.table("countries").select("*").execute()
 
@@ -195,7 +195,7 @@ if __name__ == "__main__":
 
 ```python
 import os
-from supabase import SupabaseClient 
+from supabase import SupabaseClient
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
@@ -204,15 +204,15 @@ supabase: SupabaseClient = SupabaseClient(url, key)
 data = supabase.table("countries").update({"country": "Indonesia", "capital_city": "Jakarta"}).eq("id", 1).execute()
 ```
 #### (NEW) Async Support
-    
+
 ```python
 async def main():
     import os
-    from supabase import AsyncSupabaseClient 
+    from supabase import AsyncSupabaseClient
 
     url: str = os.environ.get("SUPABASE_TEST_URL")
     key: str = os.environ.get("SUPABASE_TEST_KEY")
-    
+
     async with AsyncSupabaseClient(url, key) as supabase:
         await supabase.table("countries").update({"country": "Indonesia", "capital_city": "Jakarta"}).eq("id", 1).execute()
 
@@ -225,7 +225,7 @@ if __name__ == "__main__":
 
 ```python
 import os
-from supabase import SupabaseClient 
+from supabase import SupabaseClient
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
@@ -234,18 +234,18 @@ supabase: SupabaseClient = SupabaseClient(url, key)
 data = supabase.table("countries").delete().eq("id", 1).execute()
 ```
 #### (NEW) Async Support
-    
+
 ```python
 async def main():
     import os
-    from supabase import AsyncSupabaseClient 
+    from supabase import AsyncSupabaseClient
 
     url: str = os.environ.get("SUPABASE_TEST_URL")
     key: str = os.environ.get("SUPABASE_TEST_KEY")
-    
+
     async with AsyncSupabaseClient(url, key) as supabase:
         await supabase.table("countries").delete().eq("id", 1).execute()
-        
+
 if __name__ == "__main__":
     import asyncio
     asyncio.run(main())

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We are currently in Public Alpha. Watch "releases" of this repo to get notified 
 
 ## Installation
 
-**Recommended:** First activate your virtual environment, with your favourites' system. For example, we like `poetry` and `conda`!
+**Recommended:** First, activate your virtual environment with your favourite environment management tool. For example, we like `poetry` and `conda`!
 
 ### PyPi installation
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,23 @@ supabase: SupabaseClient = SupabaseClient(url, key)
 
 data = supabase.table("countries").insert({"name":"Germany"}).execute()
 ```
+#### (NEW) Async Support
+
+```python
+async def main():
+    import os
+    from supabase import AsyncSupabaseClient 
+
+    url: str = os.environ.get("SUPABASE_TEST_URL")
+    key: str = os.environ.get("SUPABASE_TEST_KEY")
+    
+    async with AsyncSupabaseClient(url, key) as supabase:
+        await supabase.table("countries").insert({"name":"Germany"}).execute()
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())
+```
 
 ### Select Data
 
@@ -157,7 +174,23 @@ supabase: SupabaseClient = SupabaseClient(url, key)
 
 data = supabase.table("countries").select("*").execute()
 ```
+#### (NEW) Async Support
+    
+```python
+async def main():
+    import os
+    from supabase import AsyncSupabaseClient 
 
+    url: str = os.environ.get("SUPABASE_TEST_URL")
+    key: str = os.environ.get("SUPABASE_TEST_KEY")
+    
+    async with AsyncSupabaseClient(url, key) as supabase:
+        await supabase.table("countries").select("*").execute()
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())
+```
 ### Update Data
 
 ```python
@@ -169,6 +202,23 @@ key: str = os.environ.get("SUPABASE_TEST_KEY")
 supabase: SupabaseClient = SupabaseClient(url, key)
 
 data = supabase.table("countries").update({"country": "Indonesia", "capital_city": "Jakarta"}).eq("id", 1).execute()
+```
+#### (NEW) Async Support
+    
+```python
+async def main():
+    import os
+    from supabase import AsyncSupabaseClient 
+
+    url: str = os.environ.get("SUPABASE_TEST_URL")
+    key: str = os.environ.get("SUPABASE_TEST_KEY")
+    
+    async with AsyncSupabaseClient(url, key) as supabase:
+        await supabase.table("countries").update({"country": "Indonesia", "capital_city": "Jakarta"}).eq("id", 1).execute()
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())
 ```
 
 ### Delete Data
@@ -183,7 +233,23 @@ key: str = os.environ.get("SUPABASE_TEST_KEY")
 supabase: SupabaseClient = SupabaseClient(url, key)
 data = supabase.table("countries").delete().eq("id", 1).execute()
 ```
+#### (NEW) Async Support
+    
+```python
+async def main():
+    import os
+    from supabase import AsyncSupabaseClient 
 
+    url: str = os.environ.get("SUPABASE_TEST_URL")
+    key: str = os.environ.get("SUPABASE_TEST_KEY")
+    
+    async with AsyncSupabaseClient(url, key) as supabase:
+        await supabase.table("countries").delete().eq("id", 1).execute()
+        
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())
+```
 
 ## Realtime Changes
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pip install -e .
 
 ## Usage
 
-It's usually best practice to set your API key environment variables in some way that version control doesn't track them, e.g. don't put them in your python modules! Set the Key and URL for the supabase instance in the shell, or better yet, use a dotenv file. Here's how to set the variables in the shell.
+It's usually best practice to set your API key environment variables in some way that isn't tracked by version control. For instance, don't put them in your python modules! Set the Key and URL for the supabase instance in the shell, or better yet, use a dotenv file. Here's how to set the variables in the shell.
 
 ```bash
 export SUPABASE_URL="my-url-to-my-awesome-supabase-instance"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We are currently in Public Alpha. Watch "releases" of this repo to get notified 
 
 ## Installation
 
-**Recomended:** First activate your virtual environment, with your favourites system. For example, we like `poetry` and `conda`!
+**Recommended:** First activate your virtual environment, with your favourites' system. For example, we like `poetry` and `conda`!
 
 ### PyPi installation
 
@@ -47,7 +47,7 @@ pip install -e .
 
 ## Usage
 
-It's usually best practice to set your api key environment variables in some way that version control doesn't track them, e.g don't put them in your python modules! Set the key and url for the supabase instance in the shell, or better yet, use a dotenv file. Heres how to set the variables in the shell.
+It's usually best practice to set your API key environment variables in some way that version control doesn't track them, e.g. don't put them in your python modules! Set the Key and URL for the supabase instance in the shell, or better yet, use a dotenv file. Here's how to set the variables in the shell.
 
 ```bash
 export SUPABASE_URL="my-url-to-my-awesome-supabase-instance"
@@ -58,21 +58,22 @@ We can then read the keys in the python source code.
 
 ```python
 import os
-from supabase import create_client, Client
+from supabase import SupabaseClient
 
-url: str = os.environ.get("SUPABASE_URL")
+url: str = os.environ.get("SUPABASE_URL") 
 key: str = os.environ.get("SUPABASE_KEY")
-supabase: Client = create_client(url, key)
+
+supabase: SupabaseClient = SupabaseClient(url, key)
 ```
 
 Use the supabase client to interface with your database.
 
 ### Running Tests
 
-Currently the test suites are in a state of flux. We are expanding our clients tests to ensure things are working, and for now can connect to this test instance, that is populated with the following table:
+Currently, the test suites are in a state of flux. We are expanding our clients tests to ensure things are working, and for now can connect to this test instance, that is populated with the following table:
 
 <p align="center">
-  <img width="720" height="481" src="https://i.ibb.co/Bq7Kdty/db.png">
+  <img width="720" height="481" src="https://i.ibb.co/Bq7Kdty/db.png" alt="">
 </p>
 
 The above test database is a blank supabase instance that has populated the `countries` table with the built in countries script that can be found in the supabase UI. You can launch the test scripts and point to the above test database by running
@@ -96,77 +97,90 @@ This is a sample of how you'd use supabase-py. Functions and tests are WIP
 ## Authenticate
 
 ```python
-from supabase import create_client, Client
+import os
+from supabase import SupabaseClient 
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
-supabase: Client = create_client(url, key)
+
+supabase: SupabaseClient = SupabaseClient(url, key)
+
 # Create a random user login email and password.
-random_email: str = "3hf82fijf92@supamail.com"
-random_password: str = "fqj13bnf2hiu23h"
+random_email: str = "user@supamail.com"
+random_password: str = "12345678"
 user = supabase.auth.sign_up(email=random_email, password=random_password)
 ```
 
 ## Sign-in
 
 ```python
-from supabase import create_client, Client
+import os
+from supabase import SupabaseClient 
+
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
-supabase: Client = create_client(url, key)
+supabase: SupabaseClient = SupabaseClient(url, key)
+
 # Sign in using the user email and password.
-random_email: str = "3hf82fijf92@supamail.com"
-random_password: str = "fqj13bnf2hiu23h"
+random_email: str = "user@supamail.com"
+random_password: str = "12345678"
 user = supabase.auth.sign_in(email=random_email, password=random_password)
 ```
 
 ## Managing Data
 
-### Insertion of Data
+### Insert Data
 
 ```python
-from supabase import create_client, Client
+import os
+from supabase import SupabaseClient 
+
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
-supabase: Client = create_client(url, key)
+supabase: SupabaseClient = SupabaseClient(url, key)
+
 data = supabase.table("countries").insert({"name":"Germany"}).execute()
-assert len(data.data) > 0
 ```
 
-### Selection of Data
+### Select Data
 
 ```python
-from supabase import create_client, Client
+import os
+from supabase import SupabaseClient 
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
-supabase: Client = create_client(url, key)
+
+supabase: SupabaseClient = SupabaseClient(url, key)
+
 data = supabase.table("countries").select("*").execute()
-# Assert we pulled real data.
-assert len(data.data) > 0
 ```
 
-### Update of Data
+### Update Data
 
 ```python
-from supabase import create_client, Client
+import os
+from supabase import SupabaseClient 
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
-supabase: Client = create_client(url, key)
+supabase: SupabaseClient = SupabaseClient(url, key)
+
 data = supabase.table("countries").update({"country": "Indonesia", "capital_city": "Jakarta"}).eq("id", 1).execute()
 ```
 
-### Deletion of Data
+### Delete Data
 
 ```python
-from supabase import create_client, Client
+import os
+from supabase import SupabaseClient 
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
-supabase: Client = create_client(url, key)
+
+supabase: SupabaseClient = SupabaseClient(url, key)
 data = supabase.table("countries").delete().eq("id", 1).execute()
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Use the supabase client to interface with your database.
 Currently, the test suites are in a state of flux. We are expanding our clients tests to ensure things are working, and for now can connect to this test instance, that is populated with the following table:
 
 <p align="center">
-  <img width="720" height="481" src="https://i.ibb.co/Bq7Kdty/db.png" alt="">
+  <img width="720" height="481" src="https://i.ibb.co/Bq7Kdty/db.png" alt="example of database table in Supabase Studio editor">
 </p>
 
 The above test database is a blank supabase instance that has populated the `countries` table with the built in countries script that can be found in the supabase UI. You can launch the test scripts and point to the above test database by running

--- a/supabase/__init__.py
+++ b/supabase/__init__.py
@@ -3,7 +3,9 @@ from postgrest import APIResponse as PostgrestAPIResponse
 from storage3.utils import StorageException
 
 from .__version__ import __version__
-from .client import Client, create_client
+from .exceptions import SupabaseException
+from .client import SupabaseClient, Client, create_client
+from .async_client import AsyncSupabaseClient
 from .lib.auth_client import SupabaseAuthClient
 from .lib.realtime_client import SupabaseRealtimeClient
 from .lib.storage_client import SupabaseStorageClient

--- a/supabase/__init__.py
+++ b/supabase/__init__.py
@@ -3,9 +3,9 @@ from postgrest import APIResponse as PostgrestAPIResponse
 from storage3.utils import StorageException
 
 from .__version__ import __version__
-from .exceptions import SupabaseException
-from .client import SupabaseClient, Client, create_client
 from .async_client import AsyncSupabaseClient
+from .client import Client, SupabaseClient, create_client
+from .exceptions import SupabaseException
 from .lib.auth_client import SupabaseAuthClient
 from .lib.realtime_client import SupabaseRealtimeClient
 from .lib.storage_client import SupabaseStorageClient

--- a/supabase/async_client.py
+++ b/supabase/async_client.py
@@ -1,26 +1,29 @@
 import re
-from typing import Any, Dict, Union, Coroutine
+from typing import Any, Coroutine, Dict, Union
 
 from httpx import Timeout
-from postgrest import AsyncFilterRequestBuilder, AsyncPostgrestClient, AsyncRequestBuilder
+from postgrest import (
+    AsyncFilterRequestBuilder,
+    AsyncPostgrestClient,
+    AsyncRequestBuilder,
+)
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
-
 from supafunc import FunctionsClient
+
+from .exceptions import SupabaseException
 from .lib.auth_client import SupabaseAuthClient
 from .lib.client_options import ClientOptions
 from .lib.storage_client import SupabaseStorageClient
-
-from .exceptions import SupabaseException
 
 
 class AsyncSupabaseClient:
     """Supabase client class."""
 
     def __init__(
-            self,
-            supabase_url: str,
-            supabase_key: str,
-            options: ClientOptions = ClientOptions(),
+        self,
+        supabase_url: str,
+        supabase_key: str,
+        options: ClientOptions = ClientOptions(),
     ):
         """Instantiate the client.
 
@@ -45,7 +48,9 @@ class AsyncSupabaseClient:
             raise SupabaseException("Invalid URL")
 
         # Check if the key is a valid JWT
-        if not re.match(r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$", supabase_key):
+        if not re.match(
+            r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$", supabase_key
+        ):
             raise SupabaseException("Invalid API key")
 
         self.supabase_url = supabase_url
@@ -123,7 +128,9 @@ class AsyncSupabaseClient:
         """
         return self.postgrest.from_(table_name)
 
-    def rpc(self, fn: str, params: Dict[Any, Any]) -> Coroutine[Any, Any, AsyncFilterRequestBuilder]:
+    def rpc(
+        self, fn: str, params: Dict[Any, Any]
+    ) -> Coroutine[Any, Any, AsyncFilterRequestBuilder]:
         """Performs a stored procedure call.
 
         Parameters
@@ -143,8 +150,8 @@ class AsyncSupabaseClient:
 
     @staticmethod
     def _init_supabase_auth_client(
-            auth_url: str,
-            client_options: ClientOptions,
+        auth_url: str,
+        client_options: ClientOptions,
     ) -> SupabaseAuthClient:
         """Creates a wrapped instance of the GoTrue SupabaseClient."""
         return SupabaseAuthClient(
@@ -157,11 +164,11 @@ class AsyncSupabaseClient:
 
     @staticmethod
     def _init_postgrest_client(
-            rest_url: str,
-            supabase_key: str,
-            headers: Dict[str, str],
-            schema: str,
-            timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
+        rest_url: str,
+        supabase_key: str,
+        headers: Dict[str, str],
+        schema: str,
+        timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
     ) -> AsyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
         client = AsyncPostgrestClient(

--- a/supabase/async_client.py
+++ b/supabase/async_client.py
@@ -1,12 +1,11 @@
 import re
-from typing import Any, Dict, Union
-from semver import deprecated
+from typing import Any, Dict, Union, Coroutine
 
 from httpx import Timeout
-from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequestBuilder
+from postgrest import AsyncFilterRequestBuilder, AsyncPostgrestClient, AsyncRequestBuilder
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
-from supafunc import FunctionsClient
 
+from supafunc import FunctionsClient
 from .lib.auth_client import SupabaseAuthClient
 from .lib.client_options import ClientOptions
 from .lib.storage_client import SupabaseStorageClient
@@ -14,7 +13,9 @@ from .lib.storage_client import SupabaseStorageClient
 from .exceptions import SupabaseException
 
 
-class SupabaseClient:
+class AsyncSupabaseClient:
+    """Supabase client class."""
+
     def __init__(
             self,
             supabase_url: str,
@@ -44,27 +45,28 @@ class SupabaseClient:
             raise SupabaseException("Invalid URL")
 
         # Check if the key is a valid JWT
-        if not re.match(
-                r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$", supabase_key
-        ):
+        if not re.match(r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$", supabase_key):
             raise SupabaseException("Invalid API key")
 
         self.supabase_url = supabase_url
         self.supabase_key = supabase_key
+
         options.headers.update(self._get_auth_headers())
+
         self.rest_url: str = f"{supabase_url}/rest/v1"
         self.realtime_url: str = f"{supabase_url}/realtime/v1".replace("http", "ws")
         self.auth_url: str = f"{supabase_url}/auth/v1"
         self.storage_url = f"{supabase_url}/storage/v1"
+
         is_platform = re.search(r"(supabase\.co)|(supabase\.in)", supabase_url)
         if is_platform:
             url_parts = supabase_url.split(".")
             self.functions_url = (
                 f"{url_parts[0]}.functions.{url_parts[1]}.{url_parts[2]}"
             )
-
         else:
             self.functions_url = f"{supabase_url}/functions/v1"
+
         self.schema: str = options.schema
 
         # Instantiate clients.
@@ -72,7 +74,7 @@ class SupabaseClient:
             auth_url=self.auth_url,
             client_options=options,
         )
-        # TODO: Implement realtime client
+        # TODO: Bring up to parity with JS client.
         # self.realtime: SupabaseRealtimeClient = self._init_realtime_client(
         #     realtime_url=self.realtime_url,
         #     supabase_key=self.supabase_key,
@@ -85,30 +87,43 @@ class SupabaseClient:
             schema=options.schema,
         )
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.postgrest.session.aclose()
+
     def functions(self) -> FunctionsClient:
+        """Create instance of the functions client"""
         return FunctionsClient(self.functions_url, self._get_auth_headers())
 
     def storage(self) -> SupabaseStorageClient:
         """Create instance of the storage client"""
         return SupabaseStorageClient(self.storage_url, self._get_auth_headers())
 
-    def table(self, table_name: str) -> SyncRequestBuilder:
+    def table(self, table_name: str) -> AsyncRequestBuilder:
         """Perform a table operation.
 
         Note that the supabase client uses the `from` method, but in Python,
         this is a reserved keyword, so we have elected to use the name `table`.
-        Alternatively you can use the `.from_()` method.
+        Alternatively you can use the `.on()` method.
         """
-        return self.from_(table_name)
+        return self.on(table_name)
 
-    def from_(self, table_name: str) -> SyncRequestBuilder:
+    def on(self, table_name: str) -> AsyncRequestBuilder:
+        """
+        An alias for `from_`.
+        """
+        return self.postgrest.from_(table_name)
+
+    def from_(self, table_name: str) -> AsyncRequestBuilder:
         """Perform a table operation.
 
         See the `table` method.
         """
         return self.postgrest.from_(table_name)
 
-    def rpc(self, fn: str, params: Dict[Any, Any]) -> SyncFilterRequestBuilder:
+    def rpc(self, fn: str, params: Dict[Any, Any]) -> Coroutine[Any, Any, AsyncFilterRequestBuilder]:
         """Performs a stored procedure call.
 
         Parameters
@@ -131,7 +146,7 @@ class SupabaseClient:
             auth_url: str,
             client_options: ClientOptions,
     ) -> SupabaseAuthClient:
-        """Creates a wrapped instance of the GoTrue Client."""
+        """Creates a wrapped instance of the GoTrue SupabaseClient."""
         return SupabaseAuthClient(
             url=auth_url,
             auto_refresh_token=client_options.auto_refresh_token,
@@ -147,74 +162,18 @@ class SupabaseClient:
             headers: Dict[str, str],
             schema: str,
             timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
-    ) -> SyncPostgrestClient:
+    ) -> AsyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
-        client = SyncPostgrestClient(
+        client = AsyncPostgrestClient(
             rest_url, headers=headers, schema=schema, timeout=timeout
         )
         client.auth(token=supabase_key)
         return client
 
     def _get_auth_headers(self) -> Dict[str, str]:
-        """
-        Helper method to get auth headers.
-
-        Returns
-        -------
-        Dict[str, str]
-            Returns a dictionary of headers.
-        """
+        """Helper method to get auth headers."""
+        # What's the corresponding method to get the token
         return {
             "apiKey": self.supabase_key,
             "Authorization": f"Bearer {self.supabase_key}",
         }
-
-
-class Client(SupabaseClient):
-    """
-    An alias for SupabaseClient.
-    """
-    # TODO: Remove in 0.8.0
-    pass
-
-
-@deprecated(version="0.7.1", replace="Client")
-def create_client(
-        supabase_url: str,
-        supabase_key: str,
-        options: ClientOptions = ClientOptions(),
-) -> SupabaseClient:
-    """
-    Create client function to instantiate supabase client
-
-    Parameters
-    ----------
-    supabase_url: str
-        The URL to the Supabase instance that should be connected to.
-    supabase_key: str
-        The API key to the Supabase instance that should be connected to.
-    **options
-        Any extra settings to be optionally specified - also see the
-        `DEFAULT_OPTIONS` dict.
-
-    Examples
-    --------
-    Instantiating the client.
-    >>> import os
-    >>> from supabase import create_client, SupabaseClient
-    >>>
-    >>> url: str = os.environ.get("SUPABASE_TEST_URL")
-    >>> key: str = os.environ.get("SUPABASE_TEST_KEY")
-    >>> supabase: SupabaseClient = create_client(url, key)
-
-    Returns
-    -------
-    Client
-    """
-    import warnings
-    warnings.warn(
-        "The `create_client` function is deprecated and will be removed in a future version. "
-        "Please use the `SupabaseClient` class instead.",
-        DeprecationWarning,
-    )
-    return SupabaseClient(supabase_url=supabase_url, supabase_key=supabase_key, options=options)

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -1,25 +1,24 @@
 import re
 from typing import Any, Dict, Union
-from semver import deprecated
 
 from httpx import Timeout
 from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequestBuilder
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
+from semver import deprecated
 from supafunc import FunctionsClient
 
+from .exceptions import SupabaseException
 from .lib.auth_client import SupabaseAuthClient
 from .lib.client_options import ClientOptions
 from .lib.storage_client import SupabaseStorageClient
 
-from .exceptions import SupabaseException
-
 
 class SupabaseClient:
     def __init__(
-            self,
-            supabase_url: str,
-            supabase_key: str,
-            options: ClientOptions = ClientOptions(),
+        self,
+        supabase_url: str,
+        supabase_key: str,
+        options: ClientOptions = ClientOptions(),
     ):
         """Instantiate the client.
 
@@ -45,7 +44,7 @@ class SupabaseClient:
 
         # Check if the key is a valid JWT
         if not re.match(
-                r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$", supabase_key
+            r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$", supabase_key
         ):
             raise SupabaseException("Invalid API key")
 
@@ -128,8 +127,8 @@ class SupabaseClient:
 
     @staticmethod
     def _init_supabase_auth_client(
-            auth_url: str,
-            client_options: ClientOptions,
+        auth_url: str,
+        client_options: ClientOptions,
     ) -> SupabaseAuthClient:
         """Creates a wrapped instance of the GoTrue Client."""
         return SupabaseAuthClient(
@@ -142,11 +141,11 @@ class SupabaseClient:
 
     @staticmethod
     def _init_postgrest_client(
-            rest_url: str,
-            supabase_key: str,
-            headers: Dict[str, str],
-            schema: str,
-            timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
+        rest_url: str,
+        supabase_key: str,
+        headers: Dict[str, str],
+        schema: str,
+        timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
     ) -> SyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
         client = SyncPostgrestClient(
@@ -174,15 +173,15 @@ class Client(SupabaseClient):
     """
     An alias for SupabaseClient.
     """
+
     # TODO: Remove in 0.8.0
-    pass
 
 
 @deprecated(version="0.7.1", replace="Client")
 def create_client(
-        supabase_url: str,
-        supabase_key: str,
-        options: ClientOptions = ClientOptions(),
+    supabase_url: str,
+    supabase_key: str,
+    options: ClientOptions = ClientOptions(),
 ) -> SupabaseClient:
     """
     Create client function to instantiate supabase client
@@ -212,9 +211,12 @@ def create_client(
     Client
     """
     import warnings
+
     warnings.warn(
         "The `create_client` function is deprecated and will be removed in a future version. "
         "Please use the `SupabaseClient` class instead.",
         DeprecationWarning,
     )
-    return SupabaseClient(supabase_url=supabase_url, supabase_key=supabase_key, options=options)
+    return SupabaseClient(
+        supabase_url=supabase_url, supabase_key=supabase_key, options=options
+    )

--- a/supabase/exceptions.py
+++ b/supabase/exceptions.py
@@ -1,0 +1,5 @@
+# Create an exception class when user does not provide a valid url or key.
+class SupabaseException(Exception):
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Deprecates create_client
     A Supabase client can be initialized by directly invoking the class, unlike the JS lib
- [x] Renames `Client` to `SupabaseClient`
- [x] Added async support (thanks to async postgrest-py)
- [x] Moved custom exceptions to `exceptions.py`
- [x] Rewrites README.md with typo, grammatical fixes, and includes async-related code, removes deprecated code