### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,4 +199,5 @@ See [Supabase Docs](https://supabase.com/docs/guides/client-libraries) for full 
 ## Python and Supabase Resources
 
 - [Python data loading with Supabase](https://supabase.com/blog/loading-data-supabase-python)
-- [Visualizing Supabase Data using Metabase](https://supabase.com/visualizing-supabase-data-using-metabase)
+- [Visualizing Supabase Data using Metabase](https://supabase.com/blog/visualizing-supabase-data-using-metabase)
+


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a broken link at the bottom of the README.

## What is the current behavior?

The current link is broken and leads to a 404.

## What is the new behavior?

The new link properly goes to the correct page on the Supabase blog.

## Additional context

Fixes issue reported here https://github.com/supabase-community/supabase-py/issues/304
