### PR TITLE
Update client.py

### DIFF
--- a/supabase/client.py
+++ b/supabase/client.py
@@ -66,7 +66,8 @@ class Client:
         if is_platform:
             url_parts = supabase_url.split(".")
             self.functions_url = (
-                f"{url_parts[0]}.functions.{url_parts[1]}.{url_parts[2]}"
+                f"{supabase_url}/rest/v1/rpc"
+                #f"{url_parts[0]}.functions.{url_parts[1]}.{url_parts[2]}"
             )
 
         else:


### PR DESCRIPTION
The current function url for the official Supabase client is incorrect. I am fixing it by modifying the self.function_url to the correct rpc endpoint.

## What kind of change does this PR introduce?

Bug fix
## What is the current behavior?

Currently for supabase environments that end in .co the incorrect function url is used. This results in being unable to utilize supabase functions.

## What is the new behavior?
Corrected the url used so that functions can be used.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
