### PR TITLE
Update poetry.lock; Remove dataclasses dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -412,18 +412,6 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
 
 [[package]]
-name = "dataclasses"
-version = "0.6"
-description = "A backport of the dataclasses module for Python 3.6"
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
-    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
-]
-
-[[package]]
 name = "decli"
 version = "0.5.2"
 description = "Minimal, easy-to-use, declarative cli tool"
@@ -1391,7 +1379,6 @@ files = [
 ]
 
 [package.dependencies]
-dataclasses = ">=0.6,<0.7"
 python-dateutil = ">=2.8.1,<3.0.0"
 typing-extensions = ">=4.2.0,<5.0.0"
 websockets = ">=10.3,<11.0"


### PR DESCRIPTION
- Dataclasses is no longer needed. It is a dependency needed only for Python < 3.7. Realtime, however requires Python >= 3.7, and so this dep isn't needed.


## What kind of change does this PR introduce?

- Fixes https://github.com/supabase-community/supabase-py/issues/33#issuecomment-1399638278 This issue comes up when using this library in AWS Lambda with serverless framework plugin serverless-python-requirements and this lock file makes it hard to deploy to Lambda with environments Python >= 3.7.

## Additional context

- Already removed in realtime https://github.com/supabase-community/realtime-py/pull/48
