### PR TITLE
fix: change release branch to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: codecov/codecov-action@v1
   publish:
     needs: test
-    if: ${{ !startsWith(github.event.head_commit.message, 'bump') && !startsWith(github.event.head_commit.message, 'chore') && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository_owner == 'supabase-community' }}
+    if: ${{ !startsWith(github.event.head_commit.message, 'bump') && !startsWith(github.event.head_commit.message, 'chore') && github.ref == 'refs/heads/develop' && github.event_name == 'push' && github.repository_owner == 'supabase-community' }}
     runs-on: ubuntu-latest
     name: "Bump version, create changelog and publish"
     environment:
@@ -59,7 +59,7 @@ jobs:
         if: steps.release.outputs.released == 'true'
 
       - name: Publish package distributions to GitHub Releases
-        uses: python-semantic-release/upload-to-gh-release@main
+        uses: python-semantic-release/upload-to-gh-release@develop
         if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,12 +3,11 @@ This page lists all active maintainers of this repository. If you were a maintai
 See CONTRIBUTING.md for general contribution guidelines.
 
 # Maintainers (in alphabetical order)
-
-- [anand2312](https://github.com/anand2312)
-- [dreinon](https://github.com/dreinon)
 - [J0](https://github.com/J0)
-- [leynier](https://github.com/leynier)
+- [olirice](https://github.com/olirice)
 
 # Emeritus Maintainers (in alphabetical order)
-
+- [anand2312](https://github.com/anand2312)
+- [dreinon](https://github.com/dreinon)
 - [fedden](https://github.com/fedden)
+- [leynier](https://github.com/leynier)


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Supabase-py uses `develop` as the default branch. Therefore we should release from `develop` and not `main`
- Also adds `olirice` as maintainer 
