### PR TITLE
Fix issue of RLS not working with Postgrest and Storage

### DIFF
--- a/supabase/client.py
+++ b/supabase/client.py
@@ -1,12 +1,12 @@
 import re
 from typing import Any, Dict, Union
 
+from gotrue.types import AuthChangeEvent
 from httpx import Timeout
 from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequestBuilder
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
 from supafunc import FunctionsClient
-from gotrue.types import AuthChangeEvent
 
 from .lib.auth_client import SupabaseAuthClient
 from .lib.client_options import ClientOptions

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -6,6 +6,7 @@ from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequest
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
 from supafunc import FunctionsClient
+from gotrue.types import AuthChangeEvent
 
 from .lib.auth_client import SupabaseAuthClient
 from .lib.client_options import ClientOptions
@@ -59,6 +60,7 @@ class Client:
         self.supabase_url = supabase_url
         self.supabase_key = supabase_key
         options.headers.update(self._get_auth_headers())
+        self.options = options
         self.rest_url = f"{supabase_url}/rest/v1"
         self.realtime_url = f"{supabase_url}/realtime/v1".replace("http", "ws")
         self.auth_url = f"{supabase_url}/auth/v1"
@@ -77,16 +79,11 @@ class Client:
         #     supabase_key=self.supabase_key,
         # )
         self.realtime = None
-        self.postgrest = self._init_postgrest_client(
-            rest_url=self.rest_url,
-            supabase_key=self.supabase_key,
-            headers=options.headers,
-            schema=options.schema,
-            timeout=options.postgrest_client_timeout,
-        )
+        self._postgrest = None
         self.storage = self._init_storage_client(
             self.storage_url, self._get_auth_headers(), options.storage_client_timeout
         )
+        self.auth.on_auth_state_change(self._listen_to_auth_events)
 
     def functions(self) -> FunctionsClient:
         return FunctionsClient(self.functions_url, self._get_auth_headers())
@@ -124,6 +121,18 @@ class Client:
             of an RPC.
         """
         return self.postgrest.rpc(fn, params)
+
+    @property
+    def postgrest(self):
+        if self._postgrest is None:
+            self.options.headers.update(self._get_token_header())
+            self._postgrest = self._init_postgrest_client(
+                rest_url=self.rest_url,
+                headers=self.options.headers,
+                schema=self.options.schema,
+                timeout=self.options.postgrest_client_timeout,
+            )
+        return self._postgrest
 
     #     async def remove_subscription_helper(resolve):
     #         try:
@@ -185,17 +194,14 @@ class Client:
     @staticmethod
     def _init_postgrest_client(
         rest_url: str,
-        supabase_key: str,
         headers: Dict[str, str],
         schema: str,
         timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
     ) -> SyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
-        client = SyncPostgrestClient(
+        return SyncPostgrestClient(
             rest_url, headers=headers, schema=schema, timeout=timeout
         )
-        client.auth(token=supabase_key)
-        return client
 
     def _get_auth_headers(self) -> Dict[str, str]:
         """Helper method to get auth headers."""
@@ -204,6 +210,20 @@ class Client:
             "apiKey": self.supabase_key,
             "Authorization": f"Bearer {self.supabase_key}",
         }
+
+    def _get_token_header(self):
+        try:
+            access_token = self.auth.get_session().access_token
+        except:
+            access_token = self.supabase_key
+
+        return {
+            "Authorization": f"Bearer {access_token}",
+        }
+
+    def _listen_to_auth_events(self, event: AuthChangeEvent, session):
+        # reset postgrest instance on event change
+        self._postgrest = None
 
 
 def create_client(


### PR DESCRIPTION
## What kind of change does this PR introduce?

This will now allow the correct auth headers for a authenticated user to be passed over to the postgrest client. In this setup the postgrest and storage client are lazy initialised and each time a event triggers that could cause an auth token to update we reset the private variable holding the postgrest and storage clients.

## What is the current behavior?

No complying with the RLS policies without handling it in your code yourself

## What is the new behavior?

Automatic handling of complying with the RLS polices with postgrest and storage.

## Additional context

Fixes #185 
