### PR TITLE
Ignore line endings of markdown files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: '^.*\.(md|MD)$'
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.1.0


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove markdown files from the pre-commit line endings check

## What is the current behavior?

This check is breaking the CI pipeline when we do a release

## What is the new behavior?

The CI pipeline should no longer be affected by this check

## Additional context

Add any other context or screenshots.
