### PR TITLE
feat: narrow the auth event listening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI/CD
 
-on: 
+on:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI/CD
 
-on: [pull_request, push, workflow_dispatch]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -232,7 +232,7 @@ class Client:
         }
 
     def _listen_to_auth_events(self, event: AuthChangeEvent, session):
-        if event == "SIGNED_IN" or event == "TOKEN_REFRESHED" or event == "SIGNED_OUT":
+        if event in ["SIGNED_IN", "TOKEN_REFRESHED", "SIGNED_OUT"]:
             # reset postgrest and storage instance on event change
             self._postgrest = None
             self._storage = None

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -232,9 +232,10 @@ class Client:
         }
 
     def _listen_to_auth_events(self, event: AuthChangeEvent, session):
-        # reset postgrest instance on event change
-        self._postgrest = None
-        self._storage = None
+        if event == "SIGNED_IN" or event == "TOKEN_REFRESHED" or event == "SIGNED_OUT":
+            # reset postgrest and storage instance on event change
+            self._postgrest = None
+            self._storage = None
 
 
 def create_client(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Narrow the events we listen to in order to reset the postgrest and storage libraries

## What is the current behavior?

We are listening to every event

## What is the new behavior?

We are only listening to a select few who might trigger a JWT refresh

## Additional context

Add any other context or screenshots.
