### PR TITLE
README / Storage -- Update `delete` file to `remove` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ new_file = getUserFile()
 data = supabase.storage.from_(bucket_name).upload("/user1/profile.png", new_file)
 ```
 
-### Delete a file
+### Remove a file
 
 ```python
 from supabase import create_client, Client
@@ -266,7 +266,7 @@ supabase: Client = create_client(url, key)
 
 bucket_name: str = "photos"
 
-data = supabase.storage.from_(bucket_name).delete(["old_photo.png", "image5.jpg"])
+data = supabase.storage.from_(bucket_name).remove(["old_photo.png", "image5.jpg"])
 ```
 
 ### List all files


### PR DESCRIPTION
Swap `delete` out, `remove` in the Storage section of the top-level readme.

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

Documentation is using a `delete` function to remove a file, but I was hitting an error when using it:
`AttributeError: 'SyncBucketProxy' object has no attribute 'delete'`

I'm pretty sure `remove` is the keyword that we need to use:
https://github.com/supabase-community/storage-py/blob/main/storage3/_sync/file_api.py#L277

## What is the new behavior?

n/a - no functionality changes just documentation

## Additional context

I'm brand new to supabase and really loving this project. Just hope this documentation update helps some other noob out down the line. 
