### PR TITLE
fix: add flow_type to client options

### DIFF
--- a/supabase/client.py
+++ b/supabase/client.py
@@ -210,6 +210,7 @@ class Client:
             persist_session=client_options.persist_session,
             storage=client_options.storage,
             headers=client_options.headers,
+            flow_type=client_options.flow_type,
         )
 
     @staticmethod

--- a/supabase/lib/auth_client.py
+++ b/supabase/lib/auth_client.py
@@ -1,6 +1,11 @@
 from typing import Dict, Optional
 
-from gotrue import SyncGoTrueClient, SyncMemoryStorage, SyncSupportedStorage
+from gotrue import (
+    AuthFlowType,
+    SyncGoTrueClient,
+    SyncMemoryStorage,
+    SyncSupportedStorage,
+)
 
 # TODO - export this from GoTrue-py in next release
 from httpx import Client as BaseClient
@@ -24,6 +29,7 @@ class SupabaseAuthClient(SyncGoTrueClient):
         persist_session: bool = True,
         storage: SyncSupportedStorage = SyncMemoryStorage(),
         http_client: Optional[SyncClient] = None,
+        flow_type: AuthFlowType = "implicit"
     ):
         """Instantiate SupabaseAuthClient instance."""
         if headers is None:
@@ -38,4 +44,5 @@ class SupabaseAuthClient(SyncGoTrueClient):
             persist_session=persist_session,
             storage=storage,
             http_client=http_client,
+            flow_type=flow_type,
         )

--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Union
 
-from gotrue import SyncMemoryStorage, SyncSupportedStorage
+from gotrue import AuthFlowType, SyncMemoryStorage, SyncSupportedStorage
 from httpx import Timeout
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
@@ -42,6 +42,9 @@ class ClientOptions:
     storage_client_timeout: Union[int, float, Timeout] = DEFAULT_STORAGE_CLIENT_TIMEOUT
     """Timeout passed to the SyncStorageClient instance"""
 
+    flow_type: AuthFlowType = "implicit"
+    """flow type to use for authentication"""
+
     def replace(
         self,
         schema: Optional[str] = None,
@@ -56,6 +59,7 @@ class ClientOptions:
         storage_client_timeout: Union[
             int, float, Timeout
         ] = DEFAULT_STORAGE_CLIENT_TIMEOUT,
+        flow_type: Optional[AuthFlowType] = None,
     ) -> "ClientOptions":
         """Create a new SupabaseClientOptions with changes"""
         client_options = ClientOptions()
@@ -73,4 +77,5 @@ class ClientOptions:
         client_options.storage_client_timeout = (
             storage_client_timeout or self.storage_client_timeout
         )
+        client_options.flow_type = flow_type or self.flow_type
         return client_options


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add flow_type option to client options for gotrue-py

## What is the current behavior?

Only supports `implicit` auth flow

## What is the new behavior?

Can now select between `pkce` and `implicit` auth flow

## Additional context

Add any other context or screenshots.
