### PR TITLE
feat: add create method to handle token headers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -16,24 +16,24 @@ typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
 
 [[package]]
 name = "anyio"
-version = "4.1.0"
+version = "3.7.1"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "anyio-4.1.0-py3-none-any.whl", hash = "sha256:56a415fbc462291813a94528a779597226619c8e78af7de0507333f700011e5f"},
-    {file = "anyio-4.1.0.tar.gz", hash = "sha256:5a0bec7085176715be77df87fc66d6c9d70626bd752fcc85f57cdbee5b3760da"},
+    {file = "anyio-3.7.1-py3-none-any.whl", hash = "sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5"},
+    {file = "anyio-3.7.1.tar.gz", hash = "sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780"},
 ]
 
 [package.dependencies]
-exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
 
 [package.extras]
-doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (>=0.17)"]
-trio = ["trio (>=0.23)"]
+doc = ["Sphinx", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme (>=1.2.2)", "sphinxcontrib-jquery"]
+test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=4)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (>=0.17)"]
+trio = ["trio (<0.22)"]
 
 [[package]]
 name = "argcomplete"
@@ -538,13 +538,13 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "3.6"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
-    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
+    {file = "idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"},
+    {file = "idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"},
 ]
 
 [[package]]

--- a/supabase/__init__.py
+++ b/supabase/__init__.py
@@ -4,7 +4,7 @@ from storage3.utils import StorageException
 
 from .__version__ import __version__
 from ._sync.auth_client import SyncSupabaseAuthClient as SupabaseAuthClient
-from ._sync.client import Client
+from ._sync.client import SyncClient as Client
 from ._sync.client import SyncStorageClient as SupabaseStorageClient
 from ._sync.client import create_client
 from .lib.realtime_client import SupabaseRealtimeClient

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any, Dict, Union
 
-from gotrue.types import AuthChangeEvent
+from gotrue.types import AuthChangeEvent, Session
 from httpx import Timeout
 from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequestBuilder
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
@@ -20,7 +20,7 @@ class SupabaseException(Exception):
         super().__init__(self.message)
 
 
-class Client:
+class SyncClient:
     """Supabase client class."""
 
     def __init__(
@@ -59,6 +59,9 @@ class Client:
 
         self.supabase_url = supabase_url
         self.supabase_key = supabase_key
+        self._auth_token = {
+            "Authorization": f"Bearer {supabase_key}",
+        }
         options.headers.update(self._get_auth_headers())
         self.options = options
         self.rest_url = f"{supabase_url}/rest/v1"
@@ -83,6 +86,17 @@ class Client:
         self._storage = None
         self._functions = None
         self.auth.on_auth_state_change(self._listen_to_auth_events)
+
+    @classmethod
+    def create(
+        cls,
+        supabase_url: str,
+        supabase_key: str,
+        options: ClientOptions = ClientOptions(),
+    ):
+        client = cls(supabase_url, supabase_key, options)
+        client._auth_token = client._get_token_header()
+        return client
 
     def table(self, table_name: str) -> SyncRequestBuilder:
         """Perform a table operation.
@@ -121,20 +135,21 @@ class Client:
     @property
     def postgrest(self):
         if self._postgrest is None:
-            self.options.headers.update(self._get_token_header())
+            self.options.headers.update(self._auth_token)
             self._postgrest = self._init_postgrest_client(
                 rest_url=self.rest_url,
                 headers=self.options.headers,
                 schema=self.options.schema,
                 timeout=self.options.postgrest_client_timeout,
             )
+
         return self._postgrest
 
     @property
     def storage(self):
         if self._storage is None:
             headers = self._get_auth_headers()
-            headers.update(self._get_token_header())
+            headers.update(self._auth_token)
             self._storage = self._init_storage_client(
                 storage_url=self.storage_url,
                 headers=headers,
@@ -146,7 +161,7 @@ class Client:
     def functions(self):
         if self._functions is None:
             headers = self._get_auth_headers()
-            headers.update(self._get_token_header())
+            headers.update(self._auth_token)
             self._functions = SyncFunctionsClient(self.functions_url, headers)
         return self._functions
 
@@ -229,15 +244,16 @@ class Client:
 
     def _get_token_header(self):
         try:
-            access_token = self.auth.get_session().access_token
-        except:
+            session = self.auth.get_session()
+            access_token = session.access_token
+        except Exception as err:
             access_token = self.supabase_key
 
         return {
             "Authorization": f"Bearer {access_token}",
         }
 
-    def _listen_to_auth_events(self, event: AuthChangeEvent, session):
+    def _listen_to_auth_events(self, event: AuthChangeEvent, session: Session):
         if event in ["SIGNED_IN", "TOKEN_REFRESHED", "SIGNED_OUT"]:
             # reset postgrest and storage instance on event change
             self._postgrest = None
@@ -249,7 +265,7 @@ def create_client(
     supabase_url: str,
     supabase_key: str,
     options: ClientOptions = ClientOptions(),
-) -> Client:
+) -> SyncClient:
     """Create client function to instantiate supabase client like JS runtime.
 
     Parameters
@@ -276,4 +292,6 @@ def create_client(
     -------
     Client
     """
-    return Client(supabase_url=supabase_url, supabase_key=supabase_key, options=options)
+    return SyncClient.create(
+        supabase_url=supabase_url, supabase_key=supabase_key, options=options
+    )

--- a/supabase/client.py
+++ b/supabase/client.py
@@ -4,7 +4,8 @@ from storage3.utils import StorageException
 
 from .__version__ import __version__
 from ._sync.auth_client import SyncSupabaseAuthClient as SupabaseAuthClient
-from ._sync.client import Client, ClientOptions
+from ._sync.client import ClientOptions
+from ._sync.client import SyncClient as Client
 from ._sync.client import SyncStorageClient as SupabaseStorageClient
 from ._sync.client import create_client
 from .lib.realtime_client import SupabaseRealtimeClient


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a new create method to handle async token retrieval

## What is the current behavior?

The library isn't fully async and complains when trying to call `get_session` inside of `_get_token_header` from a `@property`.

## What is the new behavior?

The library should now be fully async as the `get_session` can be called async since we've moved the `_get_token_header` to the new `create` method instead of calling it from a `@property`.

## Additional context

Add any other context or screenshots.
