### PR TITLE
fix the return type  )

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -4,17 +4,17 @@ from typing import Any, Dict, Union
 from gotrue.types import AuthChangeEvent, Session
 from httpx import Timeout
 from postgrest import (
-    AsyncFilterRequestBuilder,
     AsyncPostgrestClient,
     AsyncRequestBuilder,
 )
+from postgrest._async.request_builder import AsyncRPCFilterRequestBuilder
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from storage3 import AsyncStorageClient
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
 from supafunc import AsyncFunctionsClient
 
-from ..lib.client_options import ClientOptions
 from .auth_client import AsyncSupabaseAuthClient
+from ..lib.client_options import ClientOptions
 
 
 # Create an exception class when user does not provide a valid url or key.
@@ -118,7 +118,7 @@ class AsyncClient:
         """
         return self.postgrest.from_(table_name)
 
-    def rpc(self, fn: str, params: Dict[Any, Any]) -> AsyncFilterRequestBuilder:
+    def rpc(self, fn: str, params: Dict[Any, Any]) -> AsyncRPCFilterRequestBuilder[Any]:
         """Performs a stored procedure call.
 
         Parameters
@@ -250,7 +250,7 @@ class AsyncClient:
         try:
             session = await self.auth.get_session()
             access_token = session.access_token
-        except Exception as err:
+        except Exception:
             access_token = self.supabase_key
 
         return {


### PR DESCRIPTION


## What kind of change does this PR introduce?
update the return type in async _client def rpc(self, fn: str, params: Dict[Any, Any])->

from AsyncFilterRequestBuilder: to AsyncRPCFilterRequestBuilder[Any]:
Bug fix, feature, docs update, ...

## What is the new behavior?
None just type hint
Feel free to include screenshots if it includes visual changes.
![image](https://github.com/supabase-community/supabase-py/assets/119986792/027e0223-6a2f-481c-9b1f-937f91c36ec9)


