### PR TITLE
🐛 fix #654: Add `AsyncMemoryStorage` to `AsyncClient` options

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -2,6 +2,7 @@ import re
 from typing import Any, Dict, Union
 
 from gotrue.types import AuthChangeEvent, Session
+from gotrue._async.storage import AsyncMemoryStorage
 from httpx import Timeout
 from postgrest import (
     AsyncFilterRequestBuilder,
@@ -67,6 +68,7 @@ class AsyncClient:
             "Authorization": f"Bearer {supabase_key}",
         }
         options.headers.update(self._get_auth_headers())
+        options.storage = AsyncMemoryStorage()
         self.options = options
         self.rest_url = f"{supabase_url}/rest/v1"
         self.realtime_url = f"{supabase_url}/realtime/v1".replace("http", "ws")

--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -1,8 +1,8 @@
 import re
 from typing import Any, Dict, Union
 
-from gotrue.types import AuthChangeEvent, Session
 from gotrue._async.storage import AsyncMemoryStorage
+from gotrue.types import AuthChangeEvent, Session
 from httpx import Timeout
 from postgrest import (
     AsyncFilterRequestBuilder,

--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -32,7 +32,7 @@ class AsyncClient:
         self,
         supabase_url: str,
         supabase_key: str,
-        options: ClientOptions = ClientOptions(),
+        options: ClientOptions = ClientOptions(storage=AsyncMemoryStorage()),
     ):
         """Instantiate the client.
 
@@ -68,7 +68,6 @@ class AsyncClient:
             "Authorization": f"Bearer {supabase_key}",
         }
         options.headers.update(self._get_auth_headers())
-        options.storage = AsyncMemoryStorage()
         self.options = options
         self.rest_url = f"{supabase_url}/rest/v1"
         self.realtime_url = f"{supabase_url}/realtime/v1".replace("http", "ws")
@@ -270,7 +269,7 @@ class AsyncClient:
 async def create_client(
     supabase_url: str,
     supabase_key: str,
-    options: ClientOptions = ClientOptions(),
+    options: ClientOptions = ClientOptions(storage=AsyncMemoryStorage()),
 ) -> AsyncClient:
     """Create client function to instantiate supabase client like JS runtime.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`supabase.auth.sign_up` method [doesn't work](https://github.com/supabase-community/supabase-py/issues/654) when using `async`, it raises `TypeError`
```python
TypeError: object NoneType can't be used in 'await' expression
```

## What is the new behavior?

`supabase.auth.sign_up` method now works when using `async`

This is the same code as the issue #654:
```python
import os

import trio
from dotenv import load_dotenv

load_dotenv()


async def main():
    from supabase._async.client import AsyncClient, create_client

    DB_URL: str = os.getenv("DB_URL")
    ANON_KEY: str = os.getenv("ANON_KEY")

    supabase: AsyncClient = await create_client(DB_URL, ANON_KEY)  # works fine

    email: str = "test@gmail.com"
    password: str = "test123"

    user = await supabase.auth.sign_up({"email": email, "password": password})


trio.run(main)
```
This is the result after this PR:
```python
[🔴] × "/user/sbtest/supabase-py-fix-issue-654/test.py"
2024-01-07 13:31:10,749:INFO - HTTP Request: POST https://DBURL.supabase.co/auth/v1/signup "HTTP/1.1 200 OK"
```

## Additional context

The previous code was using `SyncMemoryStorage` from gotrue instead of using `AsyncMemoryStorage`. That's the only change I made.
