### PR TITLE
fix: add missing ClientOptions to the main init file

### DIFF
--- a/supabase/__init__.py
+++ b/supabase/__init__.py
@@ -4,6 +4,7 @@ from storage3.utils import StorageException
 
 from .__version__ import __version__
 from ._sync.auth_client import SyncSupabaseAuthClient as SupabaseAuthClient
+from ._sync.client import ClientOptions
 from ._sync.client import SyncClient as Client
 from ._sync.client import SyncStorageClient as SupabaseStorageClient
 from ._sync.client import create_client


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #682

## What is the current behavior?

Missing `ClientOptions` when importing from the `supabase` namespace

## What is the new behavior?

Adding `ClientOptions` to the `__init__.py` file

## Additional context

Add any other context or screenshots.
