### PR TITLE
Export Core Supabase Classes and Functions Explicitly via __all__

### DIFF
--- a/supabase/__init__.py
+++ b/supabase/__init__.py
@@ -9,3 +9,15 @@ from ._sync.client import SyncClient as Client
 from ._sync.client import SyncStorageClient as SupabaseStorageClient
 from ._sync.client import create_client
 from .lib.realtime_client import SupabaseRealtimeClient
+
+__all__ = [
+    'create_client',
+    'Client',
+    'SupabaseAuthClient',
+    'SupabaseStorageClient',
+    'SupabaseRealtimeClient',
+    'PostgrestAPIError',
+    'PostgrestAPIResponse',
+    'StorageException',
+    '__version__',
+]


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces a code quality improvement to the Supabase Python SDK.

## What is the current behavior?

Currently, the Supabase Python SDK does not explicitly define its public API using the __all__ variable in its __init__.py file. This omission can lead tools like PyRight to raise warnings or errors about importing unexported members. See https://arc.net/l/quote/juxuoghj

## What is the new behavior?

By specifying an __all__ list in the __init__.py file of the Supabase Python SDK, we explicitly declare the public interface of the module. This declaration prevents PyRight and similar tools from complaining about the import of unexported members, thus clearing warnings/errors related to import visibility.
