### PR TITLE
fix: Update rpc return type

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 from gotrue import AsyncMemoryStorage
 from gotrue.types import AuthChangeEvent, Session
@@ -119,7 +119,9 @@ class AsyncClient:
         """
         return self.postgrest.from_(table_name)
 
-    def rpc(self, fn: str, params: Dict[Any, Any] = {}) -> AsyncRPCFilterRequestBuilder:
+    def rpc(
+        self, fn: str, params: Optional[Dict[Any, Any]] = None
+    ) -> AsyncRPCFilterRequestBuilder:
         """Performs a stored procedure call.
 
         Parameters
@@ -135,6 +137,8 @@ class AsyncClient:
             Returns a filter builder. This lets you apply filters on the response
             of an RPC.
         """
+        if params is None:
+            params = {}
         return self.postgrest.rpc(fn, params)
 
     @property

--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -5,9 +5,9 @@ from gotrue import AsyncMemoryStorage
 from gotrue.types import AuthChangeEvent, Session
 from httpx import Timeout
 from postgrest import (
-    AsyncFilterRequestBuilder,
     AsyncPostgrestClient,
     AsyncRequestBuilder,
+    AsyncRPCFilterRequestBuilder,
 )
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from storage3 import AsyncStorageClient
@@ -119,7 +119,7 @@ class AsyncClient:
         """
         return self.postgrest.from_(table_name)
 
-    def rpc(self, fn: str, params: Dict[Any, Any]) -> AsyncFilterRequestBuilder:
+    def rpc(self, fn: str, params: Dict[Any, Any] = {}) -> AsyncRPCFilterRequestBuilder:
         """Performs a stored procedure call.
 
         Parameters

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -4,7 +4,11 @@ from typing import Any, Dict, Union
 from gotrue import SyncMemoryStorage
 from gotrue.types import AuthChangeEvent, Session
 from httpx import Timeout
-from postgrest import SyncFilterRequestBuilder, SyncPostgrestClient, SyncRequestBuilder
+from postgrest import (
+    SyncPostgrestClient,
+    SyncRequestBuilder,
+    SyncRPCFilterRequestBuilder,
+)
 from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from storage3 import SyncStorageClient
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
@@ -115,7 +119,7 @@ class SyncClient:
         """
         return self.postgrest.from_(table_name)
 
-    def rpc(self, fn: str, params: Dict[Any, Any]) -> SyncFilterRequestBuilder:
+    def rpc(self, fn: str, params: Dict[Any, Any] = {}) -> SyncRPCFilterRequestBuilder:
         """Performs a stored procedure call.
 
         Parameters

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 from gotrue import SyncMemoryStorage
 from gotrue.types import AuthChangeEvent, Session
@@ -119,7 +119,9 @@ class SyncClient:
         """
         return self.postgrest.from_(table_name)
 
-    def rpc(self, fn: str, params: Dict[Any, Any] = {}) -> SyncRPCFilterRequestBuilder:
+    def rpc(
+        self, fn: str, params: Optional[Dict[Any, Any]] = None
+    ) -> SyncRPCFilterRequestBuilder:
         """Performs a stored procedure call.
 
         Parameters
@@ -135,6 +137,8 @@ class SyncClient:
             Returns a filter builder. This lets you apply filters on the response
             of an RPC.
         """
+        if params is None:
+            params = {}
         return self.postgrest.rpc(fn, params)
 
     @property


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

This PR should be merged before https://github.com/supabase-community/postgrest-py/pull/372 in order for the version bump to happen correctly.

## What is the current behavior?

Returning wrong return type from `.rpc` method, also there is no default for `params` which means you have to pass an empty dict even if the function doesn't have any parameters.

## What is the new behavior?

Returning correct return type from `.rpc` method and now has `None` as default for `params` so you don't need to pass a dict if there are no parameters to the function.

## Additional context

In relation to #700 and https://github.com/supabase-community/postgrest-py/pull/372
