### PR TITLE
Update README.md and documentation at supabase-py web documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ user = supabase.auth.sign_up({ "email": users_email, "password": users_password 
 ### Sign-in
 
 ```python
-user = supabase.auth.sign_in_with_password({ "email": users_email, "password": users_password })
+user = supabase.auth.sign_in({ "email": users_email, "password": users_password })
 ```
 
 ### Insert Data


### PR DESCRIPTION
I tried to sign in using supabase.auth.sign_in_with_password but it wasn't working, instead it worked for below code

res = supabase.auth.sign_in(email=email, password=password)

## What kind of change does this PR introduce?

docs update

## What is the current behavior?


In my case`
data = supabase.auth.sign_in_with_password({"email": "j0@supabase.io", "password": "testsupabasenow"})` didn't work 
Instead `
data = supabase.auth.sign_in({"email": "j0@supabase.io", "password": "testsupabasenow"})`  worked

## What is the new behavior?

This should be mentioned or corrected in the documentation provided [here](https://supabase.com/docs/reference/python/auth-signinwithpassword)

## Additional context

None
