### PR TITLE
ignore paths on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - '.devcontainer/**'
+      - 'CHANGELOG.md'
+      - 'MAINTAINERS.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI shouldn't run if there is a dependency update to the CI itself

## What is the current behavior?

CI runs when there is a dependency update to the CI itself

## What is the new behavior?


## Additional context

