### PR TITLE
fix: remove default mutable argument from client creation

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -32,7 +32,7 @@ class AsyncClient:
         self,
         supabase_url: str,
         supabase_key: str,
-        options: ClientOptions = ClientOptions(storage=AsyncMemoryStorage()),
+        options: Union[ClientOptions, None] = None,
     ):
         """Instantiate the client.
 
@@ -61,6 +61,9 @@ class AsyncClient:
             r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$", supabase_key
         ):
             raise SupabaseException("Invalid API key")
+
+        if options is None:
+            options = ClientOptions(storage=AsyncMemoryStorage())
 
         self.supabase_url = supabase_url
         self.supabase_key = supabase_key
@@ -97,7 +100,7 @@ class AsyncClient:
         cls,
         supabase_url: str,
         supabase_key: str,
-        options: ClientOptions = ClientOptions(),
+        options: Union[ClientOptions, None] = None,
     ):
         client = cls(supabase_url, supabase_key, options)
         client._auth_token = await client._get_token_header()
@@ -282,7 +285,7 @@ class AsyncClient:
 async def create_client(
     supabase_url: str,
     supabase_key: str,
-    options: ClientOptions = ClientOptions(storage=AsyncMemoryStorage()),
+    options: Union[ClientOptions, None] = None,
 ) -> AsyncClient:
     """Create client function to instantiate supabase client like JS runtime.
 

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -32,7 +32,7 @@ class SyncClient:
         self,
         supabase_url: str,
         supabase_key: str,
-        options: ClientOptions = ClientOptions(storage=SyncMemoryStorage()),
+        options: Union[ClientOptions, None] = None,
     ):
         """Instantiate the client.
 
@@ -61,6 +61,9 @@ class SyncClient:
             r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$", supabase_key
         ):
             raise SupabaseException("Invalid API key")
+
+        if options is None:
+            options = ClientOptions(storage=SyncMemoryStorage())
 
         self.supabase_url = supabase_url
         self.supabase_key = supabase_key
@@ -97,7 +100,7 @@ class SyncClient:
         cls,
         supabase_url: str,
         supabase_key: str,
-        options: ClientOptions = ClientOptions(),
+        options: Union[ClientOptions, None] = None,
     ):
         client = cls(supabase_url, supabase_key, options)
         client._auth_token = client._get_token_header()
@@ -282,7 +285,7 @@ class SyncClient:
 def create_client(
     supabase_url: str,
     supabase_key: str,
-    options: ClientOptions = ClientOptions(storage=SyncMemoryStorage()),
+    options: Union[ClientOptions, None] = None,
 ) -> SyncClient:
     """Create client function to instantiate supabase client like JS runtime.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently leaking session data if you instantiate two clients in the same request.

## What is the new behavior?

No longer leaking session data.

## Additional context

Issue #762
