### PR TITLE
fix(user auth context): do not overwrite provided client options Authorization header

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -64,11 +64,8 @@ class AsyncClient:
 
         self.supabase_url = supabase_url
         self.supabase_key = supabase_key
-        self._auth_token = {
-            "Authorization": f"Bearer {supabase_key}",
-        }
-        options.headers.update(self._get_auth_headers())
         self.options = options
+        options.headers.update(self._get_auth_headers())
         self.rest_url = f"{supabase_url}/rest/v1"
         self.realtime_url = f"{supabase_url}/realtime/v1".replace("http", "ws")
         self.auth_url = f"{supabase_url}/auth/v1"
@@ -99,9 +96,7 @@ class AsyncClient:
         supabase_key: str,
         options: ClientOptions = ClientOptions(),
     ):
-        client = cls(supabase_url, supabase_key, options)
-        client._auth_token = await client._get_token_header()
-        return client
+        return cls(supabase_url, supabase_key, options)
 
     def table(self, table_name: str) -> AsyncRequestBuilder:
         """Perform a table operation.
@@ -144,7 +139,6 @@ class AsyncClient:
     @property
     def postgrest(self):
         if self._postgrest is None:
-            self.options.headers.update(self._auth_token)
             self._postgrest = self._init_postgrest_client(
                 rest_url=self.rest_url,
                 headers=self.options.headers,
@@ -157,11 +151,9 @@ class AsyncClient:
     @property
     def storage(self):
         if self._storage is None:
-            headers = self._get_auth_headers()
-            headers.update(self._auth_token)
             self._storage = self._init_storage_client(
                 storage_url=self.storage_url,
-                headers=headers,
+                headers=self.options.headers,
                 storage_client_timeout=self.options.storage_client_timeout,
             )
         return self._storage
@@ -169,9 +161,9 @@ class AsyncClient:
     @property
     def functions(self):
         if self._functions is None:
-            headers = self._get_auth_headers()
-            headers.update(self._auth_token)
-            self._functions = AsyncFunctionsClient(self.functions_url, headers)
+            self._functions = AsyncFunctionsClient(
+                self.functions_url, self.options.headers
+            )
         return self._functions
 
     #     async def remove_subscription_helper(resolve):
@@ -245,25 +237,16 @@ class AsyncClient:
         )
 
     def _create_auth_header(self, token: str):
-        return {
-            "Authorization": f"Bearer {token}",
-        }
+        return f"Bearer {token}"
 
     def _get_auth_headers(self) -> Dict[str, str]:
         """Helper method to get auth headers."""
         return {
             "apiKey": self.supabase_key,
-            "Authorization": f"Bearer {self.supabase_key}",
+            "Authorization": self.options.headers.get(
+                "Authorization", self._create_auth_header(self.supabase_key)
+            ),
         }
-
-    async def _get_token_header(self):
-        try:
-            session = await self.auth.get_session()
-            access_token = session.access_token
-        except Exception as err:
-            access_token = self.supabase_key
-
-        return self._create_auth_header(access_token)
 
     def _listen_to_auth_events(
         self, event: AuthChangeEvent, session: Union[Session, None]
@@ -276,7 +259,7 @@ class AsyncClient:
             self._functions = None
             access_token = session.access_token if session else self.supabase_key
 
-        self._auth_token = self._create_auth_header(access_token)
+        self.options.headers["Authorization"] = self._create_auth_header(access_token)
 
 
 async def create_client(

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -64,11 +64,8 @@ class SyncClient:
 
         self.supabase_url = supabase_url
         self.supabase_key = supabase_key
-        self._auth_token = {
-            "Authorization": f"Bearer {supabase_key}",
-        }
-        options.headers.update(self._get_auth_headers())
         self.options = options
+        options.headers.update(self._get_auth_headers())
         self.rest_url = f"{supabase_url}/rest/v1"
         self.realtime_url = f"{supabase_url}/realtime/v1".replace("http", "ws")
         self.auth_url = f"{supabase_url}/auth/v1"
@@ -99,9 +96,7 @@ class SyncClient:
         supabase_key: str,
         options: ClientOptions = ClientOptions(),
     ):
-        client = cls(supabase_url, supabase_key, options)
-        client._auth_token = client._get_token_header()
-        return client
+        return cls(supabase_url, supabase_key, options)
 
     def table(self, table_name: str) -> SyncRequestBuilder:
         """Perform a table operation.
@@ -144,7 +139,6 @@ class SyncClient:
     @property
     def postgrest(self):
         if self._postgrest is None:
-            self.options.headers.update(self._auth_token)
             self._postgrest = self._init_postgrest_client(
                 rest_url=self.rest_url,
                 headers=self.options.headers,
@@ -157,11 +151,9 @@ class SyncClient:
     @property
     def storage(self):
         if self._storage is None:
-            headers = self._get_auth_headers()
-            headers.update(self._auth_token)
             self._storage = self._init_storage_client(
                 storage_url=self.storage_url,
-                headers=headers,
+                headers=self.options.headers,
                 storage_client_timeout=self.options.storage_client_timeout,
             )
         return self._storage
@@ -169,9 +161,9 @@ class SyncClient:
     @property
     def functions(self):
         if self._functions is None:
-            headers = self._get_auth_headers()
-            headers.update(self._auth_token)
-            self._functions = SyncFunctionsClient(self.functions_url, headers)
+            self._functions = SyncFunctionsClient(
+                self.functions_url, self.options.headers
+            )
         return self._functions
 
     #     async def remove_subscription_helper(resolve):
@@ -245,25 +237,16 @@ class SyncClient:
         )
 
     def _create_auth_header(self, token: str):
-        return {
-            "Authorization": f"Bearer {token}",
-        }
+        return f"Bearer {token}"
 
     def _get_auth_headers(self) -> Dict[str, str]:
         """Helper method to get auth headers."""
         return {
             "apiKey": self.supabase_key,
-            "Authorization": f"Bearer {self.supabase_key}",
+            "Authorization": self.options.headers.get(
+                "Authorization", self._create_auth_header(self.supabase_key)
+            ),
         }
-
-    def _get_token_header(self):
-        try:
-            session = self.auth.get_session()
-            access_token = session.access_token
-        except Exception as err:
-            access_token = self.supabase_key
-
-        return self._create_auth_header(access_token)
 
     def _listen_to_auth_events(
         self, event: AuthChangeEvent, session: Union[Session, None]
@@ -276,7 +259,7 @@ class SyncClient:
             self._functions = None
             access_token = session.access_token if session else self.supabase_key
 
-        self._auth_token = self._create_auth_header(access_token)
+        self.options.headers["Authorization"] = self._create_auth_header(access_token)
 
 
 def create_client(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import os
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
+
+from supabase import Client, create_client
+from supabase.lib.client_options import ClientOptions
 
 
 @pytest.mark.xfail(
@@ -12,6 +17,75 @@ import pytest
 @pytest.mark.parametrize("key", ["", None, "valeefgpoqwjgpj", 139, -1, {}, []])
 def test_incorrect_values_dont_instantiate_client(url: Any, key: Any) -> None:
     """Ensure we can't instantiate client with invalid values."""
-    from supabase import Client, create_client
-
     _: Client = create_client(url, key)
+
+
+def test_uses_key_as_authorization_header_by_default() -> None:
+    url = os.environ.get("SUPABASE_TEST_URL")
+    key = os.environ.get("SUPABASE_TEST_KEY")
+
+    client = create_client(url, key)
+
+    assert client.options.headers.get("apiKey") == key
+    assert client.options.headers.get("Authorization") == f"Bearer {key}"
+
+    assert client.postgrest.session.headers.get("apiKey") == key
+    assert client.postgrest.session.headers.get("Authorization") == f"Bearer {key}"
+
+    assert client.auth._headers.get("apiKey") == key
+    assert client.auth._headers.get("Authorization") == f"Bearer {key}"
+
+    assert client.storage.session.headers.get("apiKey") == key
+    assert client.storage.session.headers.get("Authorization") == f"Bearer {key}"
+
+
+def test_supports_setting_a_global_authorization_header() -> None:
+    url = os.environ.get("SUPABASE_TEST_URL")
+    key = os.environ.get("SUPABASE_TEST_KEY")
+
+    authorization = f"Bearer secretuserjwt"
+
+    options = ClientOptions(headers={"Authorization": authorization})
+
+    client = create_client(url, key, options)
+
+    assert client.options.headers.get("apiKey") == key
+    assert client.options.headers.get("Authorization") == authorization
+
+    assert client.postgrest.session.headers.get("apiKey") == key
+    assert client.postgrest.session.headers.get("Authorization") == authorization
+
+    assert client.auth._headers.get("apiKey") == key
+    assert client.auth._headers.get("Authorization") == authorization
+
+    assert client.storage.session.headers.get("apiKey") == key
+    assert client.storage.session.headers.get("Authorization") == authorization
+
+
+def test_updates_the_authorization_header_on_auth_events() -> None:
+    url = os.environ.get("SUPABASE_TEST_URL")
+    key = os.environ.get("SUPABASE_TEST_KEY")
+
+    client = create_client(url, key)
+
+    assert client.options.headers.get("apiKey") == key
+    assert client.options.headers.get("Authorization") == f"Bearer {key}"
+
+    mock_session = MagicMock(access_token="secretuserjwt")
+    client._listen_to_auth_events("SIGNED_IN", mock_session)
+
+    updated_authorization = f"Bearer {mock_session.access_token}"
+
+    assert client.options.headers.get("apiKey") == key
+    assert client.options.headers.get("Authorization") == updated_authorization
+
+    assert client.postgrest.session.headers.get("apiKey") == key
+    assert (
+        client.postgrest.session.headers.get("Authorization") == updated_authorization
+    )
+
+    assert client.auth._headers.get("apiKey") == key
+    assert client.auth._headers.get("Authorization") == updated_authorization
+
+    assert client.storage.session.headers.get("apiKey") == key
+    assert client.storage.session.headers.get("Authorization") == updated_authorization


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #420 

Supports setting the client auth context for a particular user and therefore RLS.

- Updated both sync and async clients.
- Added unit tests.

## What is the current behavior?

If a client is created with an `Authorization` header provided in `ClientOptions`, it is overwritten with the supabase key.

For example:

```python
url = "https://example.supabase.com"
key = "apikey"
options = ClientOptions(headers={"Authorization": "Bearer userjwt"})
supabase = create_client(url, key, options)

# Subsequent requests will include the headers:
# apiKey: "apiKey"
# Authorization: "Bearer apiKey" <- Expected "Bearer userjwt"
```

## What is the new behavior?

The `Authorization` header provided via client options is used for requests.

```python
# apiKey: "apikey"
# Authorization: "Bearer userjwt"
```

If no header is provided the supabase key is used.

## Additional context

This allows us to set the auth context in the same manner [described in the official Edge Function documentation](https://supabase.com/docs/guides/functions/auth#auth-context).
