### PR TITLE
Fix timeout

### DIFF
--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -33,9 +33,7 @@ class ClientOptions:
     realtime: Optional[Dict[str, Any]] = None
     """Options passed to the realtime-py instance"""
 
-    postgrest_client_timeout: Union[
-        int, float, Timeout
-    ] = None
+    postgrest_client_timeout: Union[int, float, Timeout] = None
     """Timeout passed to the SyncPostgrestClient instance."""
 
     storage_client_timeout: Union[int, float, Timeout] = DEFAULT_STORAGE_CLIENT_TIMEOUT
@@ -52,9 +50,7 @@ class ClientOptions:
         persist_session: Optional[bool] = None,
         storage: Optional[SyncSupportedStorage] = None,
         realtime: Optional[Dict[str, Any]] = None,
-        postgrest_client_timeout: Union[
-            int, float, Timeout
-        ] = None,
+        postgrest_client_timeout: Union[int, float, Timeout] = None,
         storage_client_timeout: Union[
             int, float, Timeout
         ] = DEFAULT_STORAGE_CLIENT_TIMEOUT,

--- a/supabase/lib/client_options.py
+++ b/supabase/lib/client_options.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional, Union
 
 from gotrue import AuthFlowType, SyncMemoryStorage, SyncSupportedStorage
 from httpx import Timeout
-from postgrest.constants import DEFAULT_POSTGREST_CLIENT_TIMEOUT
 from storage3.constants import DEFAULT_TIMEOUT as DEFAULT_STORAGE_CLIENT_TIMEOUT
 
 from supabase import __version__
@@ -36,7 +35,7 @@ class ClientOptions:
 
     postgrest_client_timeout: Union[
         int, float, Timeout
-    ] = DEFAULT_POSTGREST_CLIENT_TIMEOUT
+    ] = None
     """Timeout passed to the SyncPostgrestClient instance."""
 
     storage_client_timeout: Union[int, float, Timeout] = DEFAULT_STORAGE_CLIENT_TIMEOUT
@@ -55,7 +54,7 @@ class ClientOptions:
         realtime: Optional[Dict[str, Any]] = None,
         postgrest_client_timeout: Union[
             int, float, Timeout
-        ] = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
+        ] = None,
         storage_client_timeout: Union[
             int, float, Timeout
         ] = DEFAULT_STORAGE_CLIENT_TIMEOUT,

--- a/tests/test_timeout_configuration.py
+++ b/tests/test_timeout_configuration.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 
 def test_new_timeout_configuration():
-    from supabase import create_client, Client
-    from supabase.lib.client_options import ClientOptions
     import os
+
+    from supabase import create_client
 
     url: str = os.environ.get("SUPABASE_TEST_URL")
     key: str = os.environ.get("SUPABASE_TEST_KEY")
 
     client = create_client(url, key)  # No options used here.
-    data   = [{"item": value} for value in range(0, 1000000)]
+    data = [{"item": value} for value in range(0, 1000000)]
 
     client.table("sample").insert(data).execute()
 
@@ -23,15 +21,16 @@ def test_new_timeout_configuration():
     reason="postgrest client timeout reached before processing the request."
 )
 def test_passing_wrong_timeout_value():
-    from supabase import create_client, Client
-    from supabase.lib.client_options import ClientOptions
     import os
+
+    from supabase import create_client
+    from supabase.lib.client_options import ClientOptions
 
     url: str = os.environ.get("SUPABASE_TEST_URL")
     key: str = os.environ.get("SUPABASE_TEST_KEY")
 
-    options = ClientOptions(postgrest_client_timeout = 5)  # Explicit timeout.
-    client  = create_client(url, key, options)
-    data    = [{"item": value} for value in range(0, 1000000)]
+    options = ClientOptions(postgrest_client_timeout=5)  # Explicit timeout.
+    client = create_client(url, key, options)
+    data = [{"item": value} for value in range(0, 1000000)]
 
     client.table("sample").insert(data).execute()

--- a/tests/test_timeout_configuration.py
+++ b/tests/test_timeout_configuration.py
@@ -10,11 +10,11 @@ def test_new_timeout_configuration():
     from supabase.lib.client_options import ClientOptions
     import os
 
-    url: str = os.environ.get("SUPABASE_URL")
-    key: str = os.environ.get("SUPABASE_KEY")
+    url: str = os.environ.get("SUPABASE_TEST_URL")
+    key: str = os.environ.get("SUPABASE_TEST_KEY")
 
-    client = create_client(url, key)
-    data   = [{"item": value} for value in range(0,1000000)]
+    client = create_client(url, key)  # No options used here.
+    data   = [{"item": value} for value in range(0, 1000000)]
 
     client.table("sample").insert(data).execute()
 
@@ -27,11 +27,11 @@ def test_passing_wrong_timeout_value():
     from supabase.lib.client_options import ClientOptions
     import os
 
-    url: str = os.environ.get("SUPABASE_URL")
-    key: str = os.environ.get("SUPABASE_KEY")
+    url: str = os.environ.get("SUPABASE_TEST_URL")
+    key: str = os.environ.get("SUPABASE_TEST_KEY")
 
-    options = ClientOptions(postgrest_client_timeout = 10)
+    options = ClientOptions(postgrest_client_timeout = 5)  # Explicit timeout.
     client  = create_client(url, key, options)
-    data    = [{"item": value} for value in range(0,1000000)]
+    data    = [{"item": value} for value in range(0, 1000000)]
 
     client.table("sample").insert(data).execute()

--- a/tests/test_timeout_configuration.py
+++ b/tests/test_timeout_configuration.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def test_new_timeout_configuration():
+    from supabase import create_client, Client
+    from supabase.lib.client_options import ClientOptions
+    import os
+
+    url: str = os.environ.get("SUPABASE_URL")
+    key: str = os.environ.get("SUPABASE_KEY")
+
+    client = create_client(url, key)
+    data   = [{"item": value} for value in range(0,1000000)]
+
+    client.table("sample").insert(data).execute()
+
+
+@pytest.mark.xfail(
+    reason="postgrest client timeout reached before processing the request."
+)
+def test_passing_wrong_timeout_value():
+    from supabase import create_client, Client
+    from supabase.lib.client_options import ClientOptions
+    import os
+
+    url: str = os.environ.get("SUPABASE_URL")
+    key: str = os.environ.get("SUPABASE_KEY")
+
+    options = ClientOptions(postgrest_client_timeout = 10)
+    client  = create_client(url, key, options)
+    data    = [{"item": value} for value in range(0,1000000)]
+
+    client.table("sample").insert(data).execute()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix for timeout-related issues.

According to httpx documentation setting the timeout property to `None` will ensure no timeout is used.

This could be useful when the user cannot estimate how long a running task should take, 
and improves the user experience because avoids using arbitrary values to get rid of such timeout errors.

A test to play with timeouts is included, with happy-path and expected-to-fail scenarios.

See also:

- https://github.com/encode/httpx/blob/4b85e6c3898b94e686b427afd83138c87520b479/httpx/_client.py#L81
- https://github.com/supabase-community/postgrest-py/blob/4b3a664abf2c35b7a08919ae7bf71c90f3fa9ef8/postgrest/constants.py#L6

Explicit is better than implicit.


## What is the current behavior?

- https://github.com/supabase-community/supabase-py/issues/487
- https://github.com/supabase-community/supabase-py/issues/376
- https://github.com/supabase-community/supabase-py/issues/509#issuecomment-1721348841
- https://github.com/supabase-community/supabase-py/issues/510 ???

## Notes

Another different potential approach can be just increasing the `DEFAULT_POSTGREST_CLIENT_TIMEOUT`,
a value of `5` feels too small for long-running tasks whatsoever.
JavaScript client does not have an explicit timeout **by default** (?), AFAIU.
Some libraries in the wild use `-1` or `0` to mean no explicit timeout or a very huge number likely unreachable.
If the desired approach is to use an implicit integer, then maybe using a huge number can be considered.
