### PR TITLE
Refactor create_client functions to call constructor directly

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -296,6 +296,6 @@ async def create_client(
     -------
     Client
     """
-    return await AsyncClient.create(
+    return AsyncClient(
         supabase_url=supabase_url, supabase_key=supabase_key, options=options
     )

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -296,6 +296,6 @@ def create_client(
     -------
     Client
     """
-    return SyncClient.create(
+    return SyncClient(
         supabase_url=supabase_url, supabase_key=supabase_key, options=options
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor changes discussed in #798

## What is the current behavior?

Right now, `acreate_client` is a re-import of the `_async.client.create_client` function. This function, in its body, calls the `AsyncClient.create` asynchronous class method (see [source code](https://github.com/supabase-community/supabase-py/blob/fee2b5e7ea013d06fb4e0dc6492ec053974fba10/supabase/_async/client.py#L96)). This method itself calls `AsyncClient.__init__` (see [source code](https://github.com/supabase-community/supabase-py/blob/fee2b5e7ea013d06fb4e0dc6492ec053974fba10/supabase/_async/client.py#L31)). This chain of function calls, passing the same arguments with the same names three times until it reaches the destination constructor, seems to introduce some unnecessary abstractions.

## What is the new behavior?

Both `_async.client.create_client` and `_sync.client.create_client` directly call the corresponding class's constructors (`AsyncClient.__init__` and `SyncClient.__init__`).

## Meta
Closes #798 
