### PR TITLE
feat: add schema method to the client

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -74,7 +74,6 @@ class AsyncClient:
         self.auth_url = f"{supabase_url}/auth/v1"
         self.storage_url = f"{supabase_url}/storage/v1"
         self.functions_url = f"{supabase_url}/functions/v1"
-        self.schema = options.schema
 
         # Instantiate clients.
         self.auth = self._init_supabase_auth_client(
@@ -109,6 +108,19 @@ class AsyncClient:
         Alternatively you can use the `.from_()` method.
         """
         return self.from_(table_name)
+
+    def schema(self, schema: str) -> AsyncPostgrestClient:
+        """Select a schema to query or perform an function (rpc) call.
+
+        The schema needs to be on the list of exposed schemas inside Supabase.
+        """
+        self._postgrest = self._init_postgrest_client(
+            rest_url=self.rest_url,
+            headers=self.options.headers,
+            schema=schema,
+            timeout=self.options.postgrest_client_timeout,
+        )
+        return self._postgrest
 
     def from_(self, table_name: str) -> AsyncRequestBuilder:
         """Perform a table operation.

--- a/supabase/_sync/client.py
+++ b/supabase/_sync/client.py
@@ -74,7 +74,6 @@ class SyncClient:
         self.auth_url = f"{supabase_url}/auth/v1"
         self.storage_url = f"{supabase_url}/storage/v1"
         self.functions_url = f"{supabase_url}/functions/v1"
-        self.schema = options.schema
 
         # Instantiate clients.
         self.auth = self._init_supabase_auth_client(
@@ -109,6 +108,19 @@ class SyncClient:
         Alternatively you can use the `.from_()` method.
         """
         return self.from_(table_name)
+
+    def schema(self, schema: str) -> SyncPostgrestClient:
+        """Select a schema to query or perform an function (rpc) call.
+
+        The schema needs to be on the list of exposed schemas inside Supabase.
+        """
+        self._postgrest = self._init_postgrest_client(
+            rest_url=self.rest_url,
+            headers=self.options.headers,
+            schema=schema,
+            timeout=self.options.postgrest_client_timeout,
+        )
+        return self._postgrest
 
     def from_(self, table_name: str) -> SyncRequestBuilder:
         """Perform a table operation.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove the existing schema property and add a schema method. The property wasn't being used anywhere in the code hence its removal.

## What is the current behavior?

You cannot set schema after instantiating client.

## What is the new behavior?

You can set schema using the `schema` method after instantiating the client.

## Additional context

Add any other context or screenshots.
