### PR TITLE
fix missing await in async create_client

### DIFF
--- a/supabase/_async/client.py
+++ b/supabase/_async/client.py
@@ -333,6 +333,6 @@ async def create_client(
     -------
     Client
     """
-    return AsyncClient.create(
+    return await AsyncClient.create(
         supabase_url=supabase_url, supabase_key=supabase_key, options=options
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

The async create_client method is calling `AsyncClient.create` without awaiting it, leading to the return of a nested coroutine and falsifying the return type of `create_client`.

## What is the current behavior?

Users of `create_client` need to use a double `await` to use this function, which doesn't correspond to the indicated return type.

## What is the new behavior?

The method now correctly returns a coroutine that returns an `AsyncClient` on completion.

